### PR TITLE
fix(web): Discord URL and GitHub URL examples

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -6,14 +6,30 @@ module.exports = {
   async headers() {
     return [
       {
-        source: "/api/:path*",
+        source: '/api/:path*',
         headers: [
-          { key: "Access-Control-Allow-Credentials", value: "true" },
-          { key: "Access-Control-Allow-Origin", value: "*" },
-          { key: "Access-Control-Allow-Methods", value: "GET,OPTIONS,PATCH,DELETE,POST,PUT" },
-          { key: "Access-Control-Allow-Headers", value: "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version" },
-        ]
-      }
-    ]
-  }
+          { key: 'Access-Control-Allow-Credentials', value: 'true' },
+          { key: 'Access-Control-Allow-Origin', value: '*' },
+          {
+            key: 'Access-Control-Allow-Methods',
+            value: 'GET,OPTIONS,PATCH,DELETE,POST,PUT',
+          },
+          {
+            key: 'Access-Control-Allow-Headers',
+            value:
+              'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version',
+          },
+        ],
+      },
+    ];
+  },
+  async redirects() {
+    return [
+      {
+        source: '/discord',
+        destination: 'https://discord.com/invite/n2pWEjjNnD',
+        permanent: false,
+      },
+    ];
+  },
 };

--- a/apps/web/src/components/example.tsx
+++ b/apps/web/src/components/example.tsx
@@ -13,7 +13,7 @@ interface ExampleProps {
 }
 
 const GITHUB_URL =
-  'https://github.com/zenorocha/react-email-apps/blob/main/apps/demo';
+  'https://github.com/zenorocha/react-email-apps/blob/main/apps/demo/emails';
 
 export const Example = React.forwardRef<ExampleElement, Readonly<ExampleProps>>(
   ({ className, id, name, ...props }, forwardedRef) => (

--- a/apps/web/src/components/menu.tsx
+++ b/apps/web/src/components/menu.tsx
@@ -18,7 +18,7 @@ export const Menu = React.forwardRef<MenuElement, Readonly<MenuProps>>(
       {...props}
     >
       <ul className="flex gap-2">
-        <MenuItem className="w-full px-2" href="/examples">
+        <MenuItem className="!w-fit px-2" href="/examples">
           Examples
         </MenuItem>
       </ul>

--- a/apps/web/src/components/menu.tsx
+++ b/apps/web/src/components/menu.tsx
@@ -30,7 +30,7 @@ export const Menu = React.forwardRef<MenuElement, Readonly<MenuProps>>(
         className="bg-slate-6 mx-2 hidden h-5 w-px sm:!inline-block"
       />
       <ul className="flex gap-2">
-        <MenuItem href={GITHUB_URL}>
+        <MenuItem href={GITHUB_URL} className="w-8">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="20"
@@ -43,7 +43,7 @@ export const Menu = React.forwardRef<MenuElement, Readonly<MenuProps>>(
             />
           </svg>
         </MenuItem>
-        <MenuItem href={DISCORD_URL}>
+        <MenuItem href={DISCORD_URL} className="w-8">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 127.14 96.36"
@@ -88,7 +88,7 @@ const MenuItem = React.forwardRef<MenuItemElement, Readonly<MenuItemProps>>(
     >
       <Link
         className={classnames(
-          'text-slate-11 items-center justify-center rounded-md py-2 text-sm',
+          'text-slate-11 inline-flex items-center justify-center rounded-md h-8 text-sm',
           'hover:text-slate-12 hover:bg-white/10',
           'outline-none focus:bg-white/10 focus:ring-2 focus:ring-white/20',
           className,


### PR DESCRIPTION
- Fix example link width on topbar
- Fix github url for examples
- Add redirect to discord server (so as not to break the discord link in the documentation)